### PR TITLE
Add compiler error if parameters have been modified

### DIFF
--- a/src/kem.c
+++ b/src/kem.c
@@ -8,6 +8,9 @@
 #include "sha3/fips202.h"
 #include "random/random.h"
 
+#if (PARAMS_NBAR * PARAMS_NBAR * PARAMS_EXTRACTED_BITS % 8 != 0)
+#error You have modified the cryptographic parameters. FrodoKEM reference code assumes PARAMS_NBAR * PARAMS_NBAR * PARAMS_EXTRACTED_BITS is a multiple of 8.
+#endif
 
 int crypto_kem_keypair(unsigned char* pk, unsigned char* sk)
 { // FrodoKEM's key generation


### PR DESCRIPTION
Suggested by John Schanck.  He was doing some experiments with FrodoKEM code with different parameters and ran into some unexpected errors.  Turns out it was because there were some implicit assumptions in the code that certain values were multiples of 8.  This doesn't try to fix that, just raises a compile-time error if that particular assumption is violated.