### PR TITLE
Add warning that Python3 implementation is not constant time; replace ctverify with less timing-variable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ cd python3
 python3 nist_kat.py
 ```
 
+**WARNING**: This Python3 implementation of FrodoKEM is not designed to be fast or secure, and may leak secret information via timing or other side channels; it should not be used in production environments.
+
 ## License
 
 This software is licensed under the MIT License; see the LICENSE file for details.

--- a/python3/frodokem.py
+++ b/python3/frodokem.py
@@ -5,6 +5,7 @@
 import bitstring
 import secrets
 import struct
+import warnings
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
@@ -41,7 +42,7 @@ class FrodoKEM(object):
             self.gen = self.genSHAKE128
         else:
             assert "Unknown variant"
-        print("WARNING: This Python3 implementation of FrodoKEM is not designed to be fast or secure, and may leak secret information via timing or other side channels; it should not be used in production environments.")
+        warnings.warn("WARNING: This Python3 implementation of FrodoKEM is not designed to be fast or secure, and may leak secret information via timing or other side channels; it should not be used in production environments.")
 
     def setParamsFrodo640(self):
         """Set the parameters for Frodo640"""

--- a/python3/frodokem.py
+++ b/python3/frodokem.py
@@ -41,6 +41,7 @@ class FrodoKEM(object):
             self.gen = self.genSHAKE128
         else:
             assert "Unknown variant"
+        print("WARNING: This Python3 implementation of FrodoKEM is not designed to be fast or secure, and may leak secret information via timing or other side channels; it should not be used in production environments.")
 
     def setParamsFrodo640(self):
         """Set the parameters for Frodo640"""
@@ -259,11 +260,17 @@ class FrodoKEM(object):
 
     @staticmethod
     def __ctverify(a, b):
-        """Compares two equal-length arrays in constant time; returns True if equal, False if any element differs."""
-        r = True
+        """Compares two equal-length matrices of integers; returns True if equal, False if any element differs.
+        
+        For a secure implementation, this method must be implemented in constant-time. While 
+        the Python code here is similar to a typical constant-time implementation in C, the
+        internal representation of integers in implementations of Python means that this 
+        method may not be constant-time."""
+        r = 0
         for i in range(len(a)):
-            r = r and (a[i] == b[i])
-        return r
+            for j in range(len(a[i])):
+                r = r | (a[i][j] ^ b[i][j])
+        return r == 0
 
     @staticmethod
     def __ctselect(a, b, selector):


### PR DESCRIPTION
Fixes #19.