### PR TITLE
Add support for building and continuous integration tests on PowerPC

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -103,3 +103,25 @@ jobs:
       env: 
         DO_VALGRIND_CHECK: "TRUE"
       run: make test1344
+  test-ppc:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        generation_a: ['AES128', 'SHAKE128']
+        opt_level: ['REFERENCE']
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Docker and QEMU
+      run: sudo apt-get install -y qemu
+    - name: Register qemu-user-static
+      run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
+    - name: Run tests in container
+      env:
+        GENERATION_A: ${{ matrix.generation_a }}
+        OPT_LEVEL: ${{ matrix.opt_level }}
+      run: |
+        docker run --rm -v $PWD:$PWD -w $PWD pqclean/ci-container:unstable-ppc /bin/bash -c "\
+        make ARCH=PPC GENERATION_A=${{ matrix.generation_a }} USE_OPENSSL=FALSE OPT_LEVEL=${{ matrix.opt_level }} && \
+        make test640 && \
+        make test976 && \
+        make test1344"

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -108,7 +108,7 @@ jobs:
     strategy:
       matrix:
         generation_a: ['AES128', 'SHAKE128']
-        opt_level: ['REFERENCE']
+        opt_level: ['REFERENCE', 'FAST_GENERIC']
     steps:
     - uses: actions/checkout@v2
     - name: Install Docker and QEMU

--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -108,7 +108,7 @@ jobs:
     strategy:
       matrix:
         generation_a: ['AES128', 'SHAKE128']
-        opt_level: ['REFERENCE', 'FAST_GENERIC']
+        opt_level: ['REFERENCE']
     steps:
     - uses: actions/checkout@v2
     - name: Install Docker and QEMU

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ else ifeq "$(ARCH)" "x86"
 else ifeq "$(ARCH)" "ARM"
     ARCHITECTURE=_ARM_
     USE_OPT_LEVEL=_FAST_GENERIC_
+else ifeq "$(ARCH)" "PPC"
+    ARCHITECTURE=_PPC_
+    USE_OPT_LEVEL=_FAST_GENERIC_
 endif
 
 ifeq "$(ARCHITECTURE)" "_AMD64_"
@@ -67,8 +70,11 @@ CFLAGS= $(EXTRA_CFLAGS)
 endif
 CFLAGS+= $(VALGRIND_CFLAGS)
 CFLAGS+= -std=gnu11 -Wall -Wextra -DNIX -D $(ARCHITECTURE) -D $(USE_OPT_LEVEL) -D $(USE_GENERATION_A) -D $(USING_OPENSSL)
+ifeq "$(ARCHITECTURE)" "_PPC_"
+else
 ifeq "$(CC)" "gcc"
 CFLAGS+= -march=native
+endif
 endif
 ifeq "$(USE_OPENSSL)" "FALSE"
 LDFLAGS=-lm

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ else ifeq "$(ARCH)" "ARM"
     USE_OPT_LEVEL=_FAST_GENERIC_
 else ifeq "$(ARCH)" "PPC"
     ARCHITECTURE=_PPC_
-    USE_OPT_LEVEL=_FAST_GENERIC_
+    USE_OPT_LEVEL=_REFERENCE_
 endif
 
 ifeq "$(ARCHITECTURE)" "_AMD64_"

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ $ ./frodo1344/PQCtestKAT_kem_shake
 These are all the available options for compilation:
 
 ```sh
-$ make CC=[gcc/clang] ARCH=[x64/x86/ARM] OPT_LEVEL=[REFERENCE/FAST_GENERIC/FAST] GENERATION_A=[AES128/SHAKE128] USE_OPENSSL=[TRUE/FALSE]
+$ make CC=[gcc/clang] ARCH=[x64/x86/ARM/PPC] OPT_LEVEL=[REFERENCE/FAST_GENERIC/FAST] GENERATION_A=[AES128/SHAKE128] USE_OPENSSL=[TRUE/FALSE]
 ```
 
 Note that the `FAST` option is only available for x64 with support for AVX2 and AES-NI instructions.

--- a/src/config.h
+++ b/src/config.h
@@ -44,6 +44,7 @@
 #define TARGET_AMD64        1
 #define TARGET_x86          2
 #define TARGET_ARM          3
+#define TARGET_PPC          4
 
 #if defined(_AMD64_)
     #define TARGET TARGET_AMD64 
@@ -51,6 +52,8 @@
     #define TARGET TARGET_x86
 #elif defined(_ARM_)
     #define TARGET TARGET_ARM
+#elif defined(_PPC_)
+#define TARGET TARGET_PPC
 #else
     #error -- "Unsupported ARCHITECTURE"
 #endif
@@ -96,7 +99,7 @@
 
 
 // Configuration for endianness
-#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#if (TARGET == TARGET_PPC) || (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
     #define LE_TO_UINT16(n) (((((unsigned short)(n) & 0xFF)) << 8) | (((unsigned short)(n) & 0xFF00) >> 8))
     #define UINT16_TO_LE(n) (((((unsigned short)(n) & 0xFF)) << 8) | (((unsigned short)(n) & 0xFF00) >> 8))
 #elif (TARGET == TARGET_x86 || TARGET == TARGET_AMD64) || (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))

--- a/tests/test_kem.c
+++ b/tests/test_kem.c
@@ -11,7 +11,7 @@
 #include <valgrind/memcheck.h>
 #endif
 
-#ifdef DO_VALGRIND_CHECK
+#if defined(DO_VALGRIND_CHECK) || defined(_PPC_)
 #define KEM_TEST_ITERATIONS   1
 #else
 #define KEM_TEST_ITERATIONS 100


### PR DESCRIPTION
This exercises the big endian code in liboqs by running on an emulated PowerPC in QEMU.

Uses PQClean's unstable-ppc Docker image.

Note that only the REFERENCE code is being tested.  The FAST\_GENERIC code seems to fail in this emulated environment, I haven't tried debugging that.

if you want to do some testing locally, on an Ubuntu x86\_64 host:

    apt install docker.io qemu
    docker run --rm --privileged multiarch/qemu-user-static:register --reset
    cd PQCrypto-LWEKE
    docker run -dti -v $(PWD):/PQCrypto-LWEKE pqclean/ci-container:unstable-ppc /bin/bash
    docker attach <WHATEVER ID WAS OUTPUT BY THE docker run COMMAND>

Then inside the PPC container:

    cd /PQCrypto-LWEKE
    make ARCH=PPC GENERATION_A=AES128 USE_OPENSSL=FALSE OPT_LEVEL=REFERENCE
    frodo640/test_KEM
